### PR TITLE
Fix browser-sync serve paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js": "mkdir -p dist/js && uglifyjs src/js/*.js -m -c -o dist/js/main.min.js",
 
     "build": "npm run scss && npm run imagemin && npm run js",
-    "serve": "browser-sync start --server --files 'dist/css/*.css , dis/js/*.js'",
+    "serve": "browser-sync start --server --files 'dist/css/*.css, dist/js/*.js'",
 
     "watch:css": "onchange 'src/scss/*.scss' -- npm run scss",
     "watch:js": "onchange 'src/js/*.js' -- npm run js",


### PR DESCRIPTION
## Summary
- fix dist path for browser-sync

## Testing
- `npm run build` *(fails: node-sass not found)*